### PR TITLE
Add Docker support for the backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ public class Todo {
 
 ---
 
+## 🐳 Docker Support
+
+This project includes Docker support for the backend service.
+
+### Building the Docker Image
+
+To build the Docker image for the backend, navigate to the `todo-backend` directory and run:
+
+```bash
+docker build -t todo-backend .
+```
+
+### Running the Docker Container
+
+Once the image is built, you can run the backend service in a Docker container:
+
+```bash
+docker run -p 8080:8080 todo-backend
+```
+
+This will start the Spring Boot application, and it will be accessible on port 8080 of your host machine.
+---
+
 是否需要我幫你接著生成：
 
 * Spring Boot 專案的基本骨架？

--- a/todo-backend/.dockerignore
+++ b/todo-backend/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+target/
+.idea/
+*.log

--- a/todo-backend/Dockerfile
+++ b/todo-backend/Dockerfile
@@ -1,0 +1,28 @@
+# Use a specific OpenJDK version for reproducibility
+FROM openjdk:17-jdk-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Maven wrapper and pom.xml to download dependencies
+COPY ./mvnw .
+COPY ./.mvn ./.mvn
+COPY ./pom.xml .
+
+# Download dependencies. This layer is cached Docker unless pom.xml changes.
+RUN ./mvnw dependency:go-offline -B
+
+# Copy the rest of the application source code
+COPY ./src ./src
+
+# Compile the application and package it into a JAR file
+RUN ./mvnw package -DskipTests
+
+# Expose port 8080
+EXPOSE 8080
+
+# Command to run the application
+# Replace 'your-app-name.jar' with the actual name of your JAR file if different
+# Usually, it's in the format <artifactId>-<version>.jar
+# You can find this in your pom.xml or by inspecting the target directory after building
+CMD ["java", "-jar", "target/todo-backend-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
This commit introduces Dockerization for the Spring Boot backend application.

Key changes:
- Added a `Dockerfile` in the `todo-backend` directory to build the Java application using Maven and package it into a Docker image. The image uses OpenJDK 17 and exposes port 8080.
- Added a `.dockerignore` file in `todo-backend` to exclude unnecessary files from the Docker build context, optimizing image size and build time.
- Updated `README.md` with a new "Docker Support" section, providing instructions on how to build and run the backend service using Docker.